### PR TITLE
Updated sicp/2/5.md

### DIFF
--- a/sicp/2/5.md
+++ b/sicp/2/5.md
@@ -177,14 +177,14 @@ True
 
 `<expression>` 可以是任何有效的 Python 表达式，但 `<name>` 必须是简单名称（而不是计算结果为名称的表达式）。点表达式的计算结果为作为 `<expression>` 值的对象的 `<name>` 的属性值。
 
-内置函数 `getattr` 还按名称返回对象的属性。它是点表示法的函数等效物。使用 `getattr` ，我们可以使用字符串查找属性，就像我们对调度字典所做的那样。
+内置函数 `getattr` 也可以按名称返回对象的属性。它是点表示法的函数等效物。使用 `getattr` ，我们可以使用字符串查找属性，就像我们对调度字典所做的那样。
 
 ```python
 >>> getattr(spock_account, 'balance')
 10
 ```
 
-我们还可以测试一个对象是否具有 `hasattr` 的命名属性。
+我们还可以使用 `hasattr`来测试对象是否具有指定的属性。
 
 ```python
 >>> hasattr(spock_account, 'deposit')


### PR DESCRIPTION
180行 原文为“The built-in function getattr also returns an attribute for an object by name. ”。
这里的“also”指`getattr`和点表达式拥有等价的效果，翻译成“还”不通，修改改为“也可以”。

187行 原文为“We can also test whether an object has a named attribute with hasattr.”。
翻译成“我们还可以测试一个对象是否具有 `hasattr` 的命名属性。”就完全是错误的了，修改为“我们还可以使用 `hasattr`来测试对象是否具有指定的属性。”。