### PR TITLE
fix: wrong edit link

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -52,7 +52,7 @@ export default {
     },
 
     editLink: {
-      pattern: 'https://github.com/csfive/composing-programs-zh/edit/main/docs/:path',
+      pattern: 'https://github.com/csfive/composing-programs-zh/edit/main/sicp/:path',
       text: '在 GitHub 上编辑此页面',
     },
 


### PR DESCRIPTION
The previous link of [在 GitHub 上编辑此页面](https://github.com/csfive/composing-programs-zh/edit/main/docs/2/3.md) of the pages is wrong and leads to wrong url, this pr fix it.