### PR TITLE
Update 6.md: Change function name from "find_root" to "find_zero"

### DIFF
--- a/sicp/1/6.md
+++ b/sicp/1/6.md
@@ -297,7 +297,7 @@ def <name>(n):
         return update
 ```
 
-最后，我们可以使用 `newton_update`、`improve` 算法以及比较 $f(x)$ 是否接近 0 来定义 `find_root` 函数。
+最后，我们可以使用 `newton_update`、`improve` 算法以及比较 $f(x)$ 是否接近 0 来定义 `find_zero` 函数。
 
 ```py
 >>> def find_zero(f, df):


### PR DESCRIPTION
This PR fixes a naming inconsistency in the [documentation](https://composingprograms.netlify.app/1/6#_1-6-5-%E7%A4%BA%E4%BE%8B-%E7%89%9B%E9%A1%BF%E6%B3%95). The documentation currently refers to a function called "find_root", but the actual implementation and examples use "find_zero" instead.

![image](https://github.com/user-attachments/assets/392e5424-dadc-41af-b59c-be6eac98388e)
