### PR TITLE
translate a missing-translated graph in 4.3

### DIFF
--- a/sicp/4/3.md
+++ b/sicp/4/3.md
@@ -483,8 +483,7 @@ sqlite> select sum(weight) from animals;
 sqlite> select min(legs), max(weight) from animals where name <> "t-rex";
 2|20
 ```
-
-The distinct keyword ensures that no repeated values in a column are included in the aggregation. Only two distinct values of legs appear in the animals table. The special count(*) syntax counts the number of rows.
+关键字 `distinct` 保证了聚合不将相同元素重复包含，比如 `animals`表格中只有两种`leg`的数量（2和4）。 特殊语句 `count(*)` 计算了行的数量。
 
 ```sql
 sqlite> select count(legs) from animals;


### PR DESCRIPTION
The distinct keyword ensures that no repeated values in a column are included in the aggregation. Only two distinct values of legs appear in the animals table. The special count(*) syntax counts the number of rows.    

Original version forgot to translate the paragragh