### PR TITLE
The result is missed in somewhere in 3.2:fixed

### DIFF
--- a/sicp/3/2.md
+++ b/sicp/3/2.md
@@ -147,13 +147,14 @@ Scheme 支持与 Python 相同的词法作用域规则，允许进行局部定�
 在 Scheme 语言中，`pair` 是内置的数据结构。出于历史原因，`pair` 是通过内置函数 `cons` 创建的，而元素则可以通过 `car` 和 `cdr` 进行访问：
 
 ```scheme
-(define x (cons 1 2))
-
+scm> (define x (cons 1 2))
 x
-
-(car x)
-
-(cdr x)
+scm> x
+(1 . 2)
+scm> (car x)
+1
+scm> (cdr x)
+2
 ```
 
 Scheme 语言中也内置了递归列表，它们使用 `pair` 来构建。特殊的值 `nil` 或 `'()` 表示空列表。递归列表的值是通过将其元素放在括号内，用空格分隔开来表示的：


### PR DESCRIPTION
3.2.3复合类型,此处缺少了输出结果,影响阅读的理解.
(define x (cons 1 2))

x

(car x)

(cdr x)
已经更改.