### PR TITLE
修正 2.4 节关于 identity / equality 的误译

### DIFF
--- a/sicp/2/4.md
+++ b/sicp/2/4.md
@@ -166,7 +166,7 @@ True
 
 <iframe width="100%" height="500" frameborder="0" src="https://pythontutor.com/iframe-embed.html#code=suits%20%3D%20%5B'heart',%20'diamond',%20'spade',%20'club'%5D%0Anest%20%3D%20list%28suits%29%0Anest%5B0%5D%20%3D%20suits%0Asuits.insert%282,%20'Joker'%29%0Ajoke%20%3D%20nest%5B0%5D.pop%282%29&codeDivHeight=400&codeDivWidth=350&cumulative=false&curInstr=0&heapPrimitives=nevernest&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false"> </iframe>
 
-尽管两个列表的元素值相同，但他们仍然可能是完全不同的两个列表对象，所以我们需要一个机制来验证两个对象是否相同。Python 提供了 `is` 和 `is not` 两种比较操作符来验证两个变量是否指向同一个对象。如果两个对象的值完全相等，则说明它们两个是同一个对象，对其中任意一个对象的改动都将影响到另外一个。身份验证比简单的相等验证更准确。
+尽管两个列表的元素值相同，但他们仍然可能是完全不同的两个列表对象，所以我们需要一个机制来验证两个对象是否相同。Python 提供了 `is` 和 `is not` 两种比较操作符来验证两个变量是否指向同一个对象。如果两个对象当前的值是**相等的**（*equal*），并且对其中一个对象的任何修改都会始终反映到另一个对象上，那么这两个对象就是**同一的**（*identical*）。**同一性**（*identity*）是比**相等性**（*equality*）更强的条件。
 
 ```python
 >>> suits is nest[0]


### PR DESCRIPTION
原译文有两处问题：

1. 原文“如果两个对象的值完全相等，则说明它们两个是同一个对象”
   这会误导读者认为“值相等 => 同一对象”，与后文 `==` 和 `is` 的示例不符。

2. 将 “Identity is a stronger condition than equality” 译成
   “身份验证比简单的相等验证更准确”，

本次修改改为：
“如果两个对象当前的值是相等的（equal），并且对其中一个对象的任何修改都会始终反映到另一个对象上，那么这两个对象就是同一的（identical）。同一性（identity）是比相等性（equality）更强的条件。”

这样更贴近原文，也更符合 Python 中 `is` / `is not` 与 `==` 的语义区分。

原文：
Two objects are identical if they are equal in their current value, and any change to one will always be reflected in the other. Identity is a stronger condition than equality.

原译文：
如果两个对象的值完全相等，则说明它们两个是同一个对象，对其中任意一个对象的改动都将影响到另外一个。身份验证比简单的相等验证更准确。